### PR TITLE
Add a simple homepage to render when the root URL is accessed

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,7 +12,7 @@ def home():
     current_url = urlparse(request.base_url)
     entry_point = current_url.hostname + '/data'
 
-    return 'Use the API entrypoint ' + entry_point + ' to query'
+    return 'Use the API entry point ' + entry_point + ' to query'
 
 @app.route('/data', methods = ['GET'])
 def get_data():


### PR DESCRIPTION
This PR adds a simple homepage to render when the root URL is accessed.

Currently, a "Not Found" page is being rendered when the root URL is accessed:

![image](https://user-images.githubusercontent.com/17035406/156060820-8f9c08cd-818c-4bc0-b742-2f24acce7eff.png)

This PR will create a simple homepage to redirect visitors to use `/data` instead (the localhost address will be dynamically set from `request.base_url`:

![image](https://user-images.githubusercontent.com/17035406/156061135-f4a66c6c-a4a3-489a-a36b-5e6984edac2c.png)
